### PR TITLE
Fix CSS path

### DIFF
--- a/build_transtype-reveal_template.xml
+++ b/build_transtype-reveal_template.xml
@@ -24,7 +24,7 @@
     
     <target name="reveal.init">
         <echo level="info">*****************************************************************</echo>
-        <!-- Fallback to version 4.0.1 if not defined. -->
+        <!-- Fallback to version 4.3.1 if not defined. -->
         <property unless:set="args.reveal.version" name="args.reveal.version" value="4.3.1"/>
         <echo level="info">* args.reveal.version = ${args.reveal.version}</echo>
         

--- a/build_transtype-reveal_template.xml
+++ b/build_transtype-reveal_template.xml
@@ -396,8 +396,8 @@
             </xslt>
         </pipeline>
         
-        <echo if:set="args.reveal.css" level="info">Copy ${args.reveal.css} to ${output.dir}${file.separator}css${file.separator}theme</echo>
-        <copy if:set="args.reveal.css" file="${args.reveal.css}" todir="${output.dir}${file.separator}css${file.separator}theme" failonerror="false"/>
+        <echo if:set="args.reveal.css" level="info">Copy ${args.reveal.css} to ${output.dir}${file.separator}dist${file.separator}theme</echo>
+        <copy if:set="args.reveal.css" file="${args.reveal.css}" todir="${output.dir}${file.separator}dist${file.separator}theme" failonerror="false"/>
         
         <!-- Copy reveal.js -->
         <copy todir="${output.dir}" failonerror="true">

--- a/plugin.xml
+++ b/plugin.xml
@@ -156,7 +156,7 @@
             <val>slow</val>
         </param>
         <param name="args.reveal.version" desc="Set the reveal.js version." type="string">
-            <val default="true">4.0.1</val>
+            <val default="true">4.3.1</val>
         </param>
         <param name="args.reveal.viewdistance" desc="Set the number of slides away from the current that are visible." type="string">
             <val default="true">3</val>

--- a/xsl/reveal.xsl
+++ b/xsl/reveal.xsl
@@ -79,7 +79,7 @@
         <link rel="stylesheet" href="dist/reveal.css"><!----></link>
         <xsl:choose>
             <xsl:when test="not(contains($args.reveal.theme, 'null'))">
-                <link rel="stylesheet" href="css/theme/{$args.reveal.theme}.css" id="theme"><!----></link>    
+                <link rel="stylesheet" href="dist/theme/{$args.reveal.theme}.css" id="theme"><!----></link>    
             </xsl:when>
             <xsl:otherwise>
                 <link rel="stylesheet" href="dist/reveal.css" id="theme"><!----></link>


### PR DESCRIPTION
CSS files in Reveal.js 4.x are in `dist/theme/` rather than `css/theme/` per the [upgrading instructions](https://revealjs.com/upgrading/).


341b70a0044948ac1c1fdd73dfd13bd7d8529c3a changed the default reveal version from 4.0.1 to 4.3.1. The remaining references to 4.0.1 have been updated to reflect the same.
